### PR TITLE
Fix error message

### DIFF
--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -32,7 +32,7 @@ export const randomId = (): string => Math.random().toString(16).slice(2);
 
 export const fetchConfig = async (): Promise<Config> => {
     const errorNotFound = `${NAMESPACE}: YAML config file not found.`;
-    const errorSuffix = 'Make sure you have valid config in /config/www/secret-gestures.yaml file.';
+    const errorSuffix = 'Make sure you have valid config in /config/www/secret-taps.yaml file.';
     return new Promise<Config>((resolve) => {
         fetch(`${CONFIG_PATH}?hash=${randomId()}`)
             .then((response: Response) => {


### PR DESCRIPTION
If the configuration was not present inside the `www` folder, the plugin was throwing an error stating the next sentence:

>Make sure you have valid config in /config/www/secret-gestures.yaml file

But the configuration should be placed inside a file named `secret-taps.yaml` not `secret-gestures.yaml`. This pull request fixes that.