### PR TITLE
Add a delay to the utility to call the copy config shell command service

### DIFF
--- a/tests/constants.ts
+++ b/tests/constants.ts
@@ -1,5 +1,6 @@
 export const BASE_URL = 'http://host.docker.internal:8123';
 export const MAXIMUM_RETRIES = 10;
+export const RETRY_DELAY = 200;
 export const CONFIG_PATH = 'local/secret-taps.yaml*';
 
 export const CONFIG_FILES = {

--- a/tests/utilities.ts
+++ b/tests/utilities.ts
@@ -4,6 +4,7 @@ import {
     BASE_URL,
     SELECTORS,
     MAXIMUM_RETRIES,
+    RETRY_DELAY,
     CONFIG_PATH
 } from './constants';
 
@@ -29,7 +30,13 @@ export const haConfigRequest = async (file: string = '', retries = 0) => {
         if (response.ok || retries >= MAXIMUM_RETRIES) {
             return response;
         }
-        return haConfigRequest(file, retries + 1);
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                resolve(
+                    haConfigRequest(file, retries + 1)
+                );
+            }, RETRY_DELAY);
+        });
     });
 };
 


### PR DESCRIPTION
If the call to the copy config shell command fails, add a delay of `200` before trying again. This solves some failures during the end to end tests because the Home Assistant server is not ready yet in the moment in which the tests run.