### PR TITLE
Change navigation path in the docs and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ entity_id: sun.sun
 
 ```yaml
 action: navigate
-navigation_path: config/dashboard
+navigation_path: /config/dashboard
 ## Optional parameter. It is false by default
 ## Whether to replace the current page in the history 
 navigation_replace: true 
@@ -201,7 +201,7 @@ profiles:
         - double-tap
         - tap
         action: navigate
-        navigation_path: config/dashboard
+        navigation_path: /config/dashboard
   ## This profile will match only with non-admin users
   - admin: false
     secrets:

--- a/secret-taps.yaml
+++ b/secret-taps.yaml
@@ -15,7 +15,7 @@ profiles:
         - double-tap
         - tap
         action: navigate
-        navigation_path: config/dashboard
+        navigation_path: /config/dashboard
   - admin: false
     secrets:
       - taps:


### PR DESCRIPTION
This pull request adds a slash at the beginning of the `navigation_path` parameters in the documentation and the example config, because it can confuse users. If it doesn't have a slash at the beginning, it will be apended to the current URL.