### PR TITLE
Create a Nightly Beta tests workflow

### DIFF
--- a/.github/workflows/ha-beta-tests.yaml
+++ b/.github/workflows/ha-beta-tests.yaml
@@ -1,0 +1,40 @@
+name: Home Assistant Nightly Beta Tests
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:      
+  beta-tests:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 8
+          run_install: false
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'pnpm'
+      - name: Install
+        run: pnpm install
+      - name: E2E Tests
+        run: |
+          touch .env
+          echo HA_TOKEN=${{ secrets.HA_TOKEN }} >> .env
+          TAG=beta pnpm test:ci
+      - name: Create coverage
+        run: pnpm coverage:report
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: test-report
+          path: |
+            playwright-report/
+            coverage/
+          retention-days: 30


### PR DESCRIPTION
This pull request creates a Nightly beta test workflow to run the tests agains the latest Docker beta tag and detect any issue before the final version is released.