### PR TITLE
Create a Husky pre-commit hook to update the Playground docker image version

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,14 @@
+PACKAGE_JSON="package.json"
+PLAYWRIGHT_FILE=".playwright_docker_version"
+MODIFIED_FILES=$(git diff --staged --name-only)
+if [[ $MODIFIED_FILES = *$PACKAGE_JSON* ]]; then
+    echo "$PACKAGE_JSON has been modified, checking if Playwright was updated..."
+    PLAYWRIGHT_VERSION=$(node -p -e "require('./$PACKAGE_JSON').devDependencies['@playwright/test']" | sed 's/^\^\([0-9]*\.[0-9]*\.[0-9]*\)$/\1/')
+    CURRENT_PLAYWRIGHT_VERSION=$(cat "$PLAYWRIGHT_FILE")
+    if [[ $CURRENT_PLAYWRIGHT_VERSION != v"$PLAYWRIGHT_VERSION"-jammy ]]; then
+        echo "Playwright version has been updated to version $PLAYWRIGHT_VERSION"
+        echo "Updating $PLAYWRIGHT_FILE file"
+        printf "v$PLAYWRIGHT_VERSION-jammy" > "$PLAYWRIGHT_FILE"
+        git add .
+    fi
+fi

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "coverage:report": "nyc report --reporter=lcov --reporter=text-summary",
     "reset:ha": "git add .hass/config/.HA_VERSION && git checkout .hass/config",
     "preinstall": "npx -y only-allow pnpm",
-    "prepare": "pnpm build",
+    "husky:setup": "husky",
+    "prepare": "pnpm build && pnpm husky:setup",
     "prepublishOnly": "pnpm test:ts",
     "version": "git add .",
     "postversion": "git push && git push --tags"
@@ -40,6 +41,7 @@
     "@types/node": "^20.12.7",
     "dotenv-cli": "^7.4.1",
     "eslint": "^9.0.0",
+    "husky": "^9.0.11",
     "nyc": "^15.1.0",
     "playwright-test-coverage": "^1.2.12",
     "rollup": "^4.14.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,6 +46,9 @@ devDependencies:
   eslint:
     specifier: ^9.0.0
     version: 9.0.0
+  husky:
+    specifier: ^9.0.11
+    version: 9.0.11
   nyc:
     specifier: ^15.1.0
     version: 15.1.0
@@ -1513,6 +1516,12 @@ packages:
 
   /html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+    dev: true
+
+  /husky@9.0.11:
+    resolution: {integrity: sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==}
+    engines: {node: '>=18'}
+    hasBin: true
     dev: true
 
   /ignore@5.3.1:


### PR DESCRIPTION
Every time that the `@playwright/test` is updated, the `.playwright_docker_version` gets outdated. If it is a patch update nothing happens, but if it is a major/minor update multiple times the tests fail because the versin of the Docker image and the version of the package don't match, so a manual work is required in those cases. This is pretty common during Dependabot updates.

This pull request creates a small Husky hook before any commit to check if the `@playwright/test` package has been updated. If the package has been updated, it updates the `.playwright_docker_version` file with the proper version and add it to the commit changes.