### PR TITLE
Fix test failure in the new Home Assistant beta version

### DIFF
--- a/tests/03 - notifications.spec.ts
+++ b/tests/03 - notifications.spec.ts
@@ -8,7 +8,7 @@ import {
     doubleTap
 } from './utilities';
 
-const TOAST_FAILURE = 'Failed to call service input_boolean/toggle';
+const TOAST_FAILURE = /^Failed.*?input_boolean\/toggle.*$/;
 const VISIBILITY_OPTIONS = { timeout: 0 };
 
 test.describe('Notifications disabled', () => {


### PR DESCRIPTION
In the coming version of Home Assistant, error texts calling a service have changed. This pull request uses a regular expression to match the current error messages and the coming ones and in this way make the tests work with the current and the coming version.