### PR TITLE
Remove getPromisableElement utility

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "typescript-eslint": "^8.13.0"
   },
   "dependencies": {
+    "get-promisable-result": "^1.0.1",
     "hammerjs": "^2.0.8",
     "home-assistant-query-selector": "^4.3.0",
     "js-yaml": "^4.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      get-promisable-result:
+        specifier: ^1.0.1
+        version: 1.0.1
       hammerjs:
         specifier: ^2.0.8
         version: 2.0.8

--- a/src/checker.ts
+++ b/src/checker.ts
@@ -1,34 +1,14 @@
+import { getPromisableResult } from 'get-promisable-result';
 import { NAMESPACE } from '@constants';
 
-export const MAX_ATTEMPTS = 100;
-export const RETRY_DELAY = 50;
-
-const getPromisableElement = <T>(
-    getElement: () => T,
-    check: (element: T) => boolean
-): Promise<T> => {
-    return new Promise<T>((resolve) => {
-        let attempts = 0;
-        const select = () => {
-            const element: T = getElement();
-            if (element && check(element)) {
-                resolve(element);
-            } else {
-                attempts++;
-                if (attempts < MAX_ATTEMPTS) {
-                    setTimeout(select, RETRY_DELAY);
-                } else {
-                    resolve(element);
-                }
-            }
-        };
-        select();
-    });
-};
-
-getPromisableElement(
+getPromisableResult(
     () => window.HomeAssistantSecretTaps,
-    (module: object) => !!module
+    (module: object) => !!module,
+    {
+        retries: 100,
+        delay: 50,
+        shouldReject: false
+    }
 ).then((module) => {
     if (!module) {
         throw Error(`${NAMESPACE}: you need to add the plugin as a frontend > extra_module_url module.\nCheck the documentation: https://github.com/elchininet/home-assistant-secret-taps#installation`);


### PR DESCRIPTION
This pull request removes the `getPromisableElement` utility and replace it by the `getPromisableResult` from [get-promisable-result](https://github.com/elchininet/get-promisable-result) package.