### PR TITLE
Add a new option to execute JavaScript code

### DIFF
--- a/.hass/config/www/home-assistant-secret-taps-configs/basic.yaml
+++ b/.hass/config/www/home-assistant-secret-taps-configs/basic.yaml
@@ -34,3 +34,12 @@ profiles:
         action: navigate
         navigation_path: /media-browser/browser
         navigation_replace: true
+      - taps:
+        - double-tap
+        - tap
+        - tap
+        action: javascript
+        code: |
+          if (user_is_admin) {
+            location.hash = 'something';
+          } 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ taps:
 * `more-info`: action to open a more-info dialog
 * `navigate`: action to navigate to a certain path
 * `toggle-menu`: action to open or close the sidebar
+* `javascript`: action to execute a `JavaScript` code block
 
 Each `secret` can be any of the next ones:
 
@@ -193,6 +194,18 @@ navigation_replace: true
 ```yaml
 action: toggle-menu
 ```
+
+**JavaScript secret example**
+
+```yaml
+action: javascript
+code: |
+  if (user_is_admin) {
+    location.reload();
+  } 
+```
+
+>Note: the `JavaScript` action makes use of the [home-assistant-javascript-templates](https://github.com/elchininet/home-assistant-javascript-templates) library. So all the [objects and methods of this library](https://github.com/elchininet/home-assistant-javascript-templates?tab=readme-ov-file#objects-and-methods-available-in-the-templates) will be available in the `JavaScript` code.
 
 ### Configuration example
 
@@ -235,6 +248,13 @@ profiles:
         - tap
         - triple-tap
         action: toggle-menu
+      - taps:
+        - double-tap
+        - tap
+        - tap
+        action: javascript
+        code: 'location.reload();'
+
 ```
 
 [kiosk-mode]: https://github.com/NemesisRE/kiosk-mode

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,37 +3,43 @@ const js = require('@eslint/js');
 const globals = require('globals');
 
 module.exports = [
-	{
-		languageOptions: {
-			globals: {
-				Atomics: 'readonly',
-				SharedArrayBuffer: 'readonly',
-				...globals.browser,
-				...globals.node,
-				...globals.es2015
-			}
-		}
-	},
-	js.configs.recommended,
-	...tseslint.configs.recommended,
-	{
-		rules: {
-			quotes: [
-				'error',
-				'single',
-				{
-					avoidEscape: true,
-					allowTemplateLiterals: true
-				}
-			],
-			indent: ['error', 4],
-			semi: ['error', 'always'],
-			'comma-dangle': ['error', 'never'],
-			'no-trailing-spaces': ['error'],
-			'array-bracket-spacing': ['error', 'never'],
-			'comma-spacing': ['error'],
-			'@typescript-eslint/no-duplicate-enum-values': 'off',
-			'@typescript-eslint/no-var-requires': 'off'
-		}
-	}
+    {
+        languageOptions: {
+            globals: {
+                Atomics: 'readonly',
+                SharedArrayBuffer: 'readonly',
+                ...globals.browser,
+                ...globals.node,
+                ...globals.es2015
+            }
+        }
+    },
+    js.configs.recommended,
+    ...tseslint.configs.recommended,
+    {
+        rules: {
+            quotes: [
+                'error',
+                'single',
+                {
+                    avoidEscape: true,
+                    allowTemplateLiterals: true
+                }
+            ],
+            indent: ['error', 4],
+            semi: ['error', 'always'],
+            'comma-dangle': ['error', 'never'],
+            'no-trailing-spaces': ['error'],
+            'array-bracket-spacing': ['error', 'never'],
+            'comma-spacing': ['error'],
+            '@typescript-eslint/no-duplicate-enum-values': 'off',
+            '@typescript-eslint/no-var-requires': 'off'
+        }
+    },
+    {
+        files: ['eslint.config.js'],
+        rules: {
+            '@typescript-eslint/no-require-imports': 'off'
+        }
+    }
 ];

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@types/node": "^22.9.0",
     "dotenv-cli": "^7.4.2",
     "eslint": "^9.14.0",
+    "globals": "^15.12.0",
     "nyc": "^17.1.0",
     "playwright-test-coverage": "^1.2.12",
     "rollup": "^4.25.0",
@@ -52,6 +53,7 @@
   "dependencies": {
     "get-promisable-result": "^1.0.1",
     "hammerjs": "^2.0.8",
+    "home-assistant-javascript-templates": "^5.5.0",
     "home-assistant-query-selector": "^4.3.0",
     "js-yaml": "^4.1.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       hammerjs:
         specifier: ^2.0.8
         version: 2.0.8
+      home-assistant-javascript-templates:
+        specifier: ^5.5.0
+        version: 5.5.0
       home-assistant-query-selector:
         specifier: ^4.3.0
         version: 4.3.0
@@ -51,6 +54,9 @@ importers:
       eslint:
         specifier: ^9.14.0
         version: 9.14.0
+      globals:
+        specifier: ^15.12.0
+        version: 15.12.0
       nyc:
         specifier: ^17.1.0
         version: 17.1.0
@@ -964,6 +970,10 @@ packages:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
 
+  globals@15.12.0:
+    resolution: {integrity: sha512-1+gLErljJFhbOVyaetcwJiJ4+eLe45S2E7P5UiZ9xGfeq3ATQf5DOv9G7MH3gGbKQLkzmNh2DxfZwLdw+j6oTQ==}
+    engines: {node: '>=18'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -993,6 +1003,9 @@ packages:
   helpertypes@0.0.19:
     resolution: {integrity: sha512-J00e55zffgi3yVnUp0UdbMztNkr2PnizEkOe9URNohnrNhW5X0QpegkuLpOmFQInpi93Nb8MCjQRHAiCDF42NQ==}
     engines: {node: '>=10.0.0'}
+
+  home-assistant-javascript-templates@5.5.0:
+    resolution: {integrity: sha512-lbjNMjeZeYSu3qBCu5/yRTdH+g1Oz5vy6RPh8V8114M9c5BIeNiD2nRB2CT6OB4A+UjMNPU1bPldzgj+ahW69Q==}
 
   home-assistant-query-selector@4.3.0:
     resolution: {integrity: sha512-L+TfdKKlqKAijIp/dWYKmtQWmTT+S9CZOM43L1lu1azPwVqIhJ2nlzf4GZ1MpWlGjY0+kn4sip0TYxvSCpZeeg==}
@@ -2540,6 +2553,8 @@ snapshots:
 
   globals@14.0.0: {}
 
+  globals@15.12.0: {}
+
   graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
@@ -2560,6 +2575,10 @@ snapshots:
       function-bind: 1.1.2
 
   helpertypes@0.0.19: {}
+
+  home-assistant-javascript-templates@5.5.0:
+    dependencies:
+      get-promisable-result: 1.0.1
 
   home-assistant-query-selector@4.3.0:
     dependencies:

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,7 +17,8 @@ export enum ServiceType {
     CALL_SERVICE = 'call-service',
     MORE_INFO = 'more-info',
     NAVIGATE = 'navigate',
-    TOGGLE_MENU = 'toggle-menu'
+    TOGGLE_MENU = 'toggle-menu',
+    JAVASCRIPT = 'javascript'
 }
 
 interface SecretBase {
@@ -45,11 +46,17 @@ export interface ToggleMenuSecret extends SecretBase {
     action: `${ServiceType.TOGGLE_MENU}`
 }
 
+export interface JavaScriptSecret extends SecretBase {
+    action: `${ServiceType.JAVASCRIPT}`,
+    code: string;
+}
+
 export type Secret =
     | ServiceSecret
     | MoreInfoSecret
     | NavigateSecret
-    | ToggleMenuSecret;
+    | ToggleMenuSecret
+    | JavaScriptSecret;
 
 export interface Profile {
     user?: string | string[];

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -8,6 +8,7 @@ import {
     MoreInfoSecret,
     NavigateSecret,
     ToggleMenuSecret,
+    JavaScriptSecret,
     ServiceType
 } from '@types';
 import {
@@ -109,6 +110,10 @@ export const isNavigateSecret = (secret: Secret): secret is NavigateSecret => {
 
 export const isToggleMenuSecret = (secret: Secret): secret is ToggleMenuSecret => {
     return secret.action === ServiceType.TOGGLE_MENU;
+};
+
+export const isJavaScriptSecret = (secret: Secret): secret is JavaScriptSecret => {
+    return secret.action === ServiceType.JAVASCRIPT && !!secret.code;
 };
 
 export const compareArrays = <T>(arrayA: T[], arrayB: T[]): boolean => {

--- a/tests/01 - actions.spec.ts
+++ b/tests/01 - actions.spec.ts
@@ -124,3 +124,19 @@ test('Navigate to a panel replacing history', async ({ page }) => {
     expect(page.url()).not.toBe(`${BASE_URL}/lovelace/home`);
 
 });
+
+test('Execute a JavaScript code', async ({ page }) => {
+
+    await pageVisit(page);
+
+    expect(page.url()).toBe(`${BASE_URL}/lovelace/home`);
+
+    await moveToHeader(page);
+    await doubleTap(page);
+    await tap(page);
+    await tap(page);
+    await page.waitForTimeout(1500);
+
+    expect(page.url()).toBe(`${BASE_URL}/lovelace/home#something`);
+    
+});


### PR DESCRIPTION
This pull request adds support for a new action to execute arbitrary `JavaScript` code.

**JavaScript secret example**

```yaml
action: javascript
code: |
  if (user_is_admin) {
    location.reload();
  } 
```

>Note: the `JavaScript` action makes use of the [home-assistant-javascript-templates](https://github.com/elchininet/home-assistant-javascript-templates) library. So all the [objects and methods of this library](https://github.com/elchininet/home-assistant-javascript-templates?tab=readme-ov-file#objects-and-methods-available-in-the-templates) will be available in the `JavaScript` code.