### PR TITLE
Remove @babel/helpers pnpm override

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,10 +54,5 @@
     "home-assistant-javascript-templates": "^5.7.1",
     "home-assistant-query-selector": "^4.3.0",
     "js-yaml": "^4.1.0"
-  },
-  "pnpm": {
-    "overrides": {
-      "@babel/helpers@<7.26.10": ">=7.26.10"
-    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  '@babel/helpers@<7.26.10': '>=7.26.10'
-
 importers:
 
   .:


### PR DESCRIPTION
This pull request removes the `pnpm`override of `@babel/helpers` because this transitive dependency has been already updated in one of the dependant packages.