### PR TITLE
Rollback pnpm/action-setup to version 5

### DIFF
--- a/.github/workflows/ha-beta-tests.yaml
+++ b/.github/workflows/ha-beta-tests.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v5
         with:
           version: 10
           run_install: false


### PR DESCRIPTION
This pull request rollbacks the GitHub action `pnpm/action-setup` because the new version tries to use `pnpm` 11 even if it is configured to use 10.